### PR TITLE
Test enhancement

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,21 @@
-<phpunit
-    forceCoversAnnotation="true"
->
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
     <testsuites>
-        <testsuite name="All">
-            <directory>tests/unit</directory>
+        <testsuite name="Unit tests">
+            <directory suffix="Test.php">./tests/unit</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/unit/ScheduleTest.php
+++ b/tests/unit/ScheduleTest.php
@@ -16,7 +16,7 @@ class ScheduleTest extends TestCase
     /** @var Schedule */
     private $schedule;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->schedule = (new Schedule)
             ->requireUpToDateDataFrom(Schedule::MON, 8, 0)
@@ -29,6 +29,11 @@ class ScheduleTest extends TestCase
             ->allowStaleDataFrom(Schedule::THU, 17, 30)
             ->requireUpToDateDataFrom(Schedule::FRI, 8, 0)
             ->allowStaleDataFrom(Schedule::FRI, 17, 30);
+    }
+
+    public function testIsClear()
+    {
+        $this->assertFalse($this->schedule->isClear());
     }
 
     /**

--- a/tests/unit/SchedulerTest.php
+++ b/tests/unit/SchedulerTest.php
@@ -28,7 +28,7 @@ class SchedulerTest extends TestCase
     /** @var ObjectProphecy */
     private $systemClock;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->schedule = $this->prophesize(Schedule::class);
         $this->systemClock = $this->prophesize(SystemClock::class);
@@ -188,6 +188,6 @@ class SchedulerTest extends TestCase
             ->setSchedule($this->schedule->reveal())
             ->setExpirationSpread($expirationSpread->reveal());
 
-        $this->assertEquals(21060, $scheduler->calculateTimeToLive(self::DEFAULT_TTL), '', 1800);
+        $this->assertEquals(21060, $scheduler->calculateTimeToLive(self::DEFAULT_TTL), '', 1800.0);
     }
 }

--- a/tests/unit/SwitchOverPointTest.php
+++ b/tests/unit/SwitchOverPointTest.php
@@ -145,4 +145,32 @@ class SwitchOverPointTest extends TestCase
             ],
         ];
     }
+
+    public function testGetDayOfTheWeek()
+    {
+        $switchOverPoint = new SwitchOverPoint(Schedule::WED, 14, 30, Schedule::STATE_STALE);
+
+        $this->assertEquals(3, $switchOverPoint->getDayOfTheWeek());
+    }
+
+    public function testGetHour()
+    {
+        $switchOverPoint = new SwitchOverPoint(Schedule::WED, 14, 30, Schedule::STATE_STALE);
+
+        $this->assertEquals(14, $switchOverPoint->getHour());
+    }
+
+    public function testGetMinute()
+    {
+        $switchOverPoint = new SwitchOverPoint(Schedule::WED, 14, 30, Schedule::STATE_STALE);
+
+        $this->assertEquals(30, $switchOverPoint->getMinute());
+    }
+
+    public function testGetState()
+    {
+        $switchOverPoint = new SwitchOverPoint(Schedule::WED, 14, 30, Schedule::STATE_STALE);
+
+        $this->assertEquals('stale', $switchOverPoint->getState());
+    }
 }

--- a/tests/unit/SystemClockTest.php
+++ b/tests/unit/SystemClockTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace ErikBooij\Tests\CacheScheduler;
+
+use DateTimeImmutable;
+use ErikBooij\CacheScheduler\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+class SystemClockTest extends TestCase
+{
+    public function testCurrentDateTime()
+    {
+        $systemClock = new SystemClock();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $systemClock->currentDateTime());
+    }
+}


### PR DESCRIPTION
# Changed log
- Add the missed tests for other methods on classes.
- Enhance the `phpunit.xml.dist` setting file to keep this file completed.
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/7.4/assertions.html#assertfalse), the final `$delta` parameter in `TestCase::assertEquals` should be `float` type. And the passed argument should be `1800.0`, not `1800`.
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `TestCase::setUp` should be `protected`, not `public`.